### PR TITLE
Setup test framework

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ rvm:
   - 2.3.3
 sudo: false
 cache: bundler
+script:
+  - bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ rvm:
 sudo: false
 cache: bundler
 script:
+  - bash <(curl -fsSL https://github.com/everypolitician/ensure-regression-tests/raw/v0.1.0/ensure-regression-tests)
   - bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'rest-client'
 gem 'rubocop'
 gem 'scraped', github: 'everypolitician/scraped'
 gem 'scraped_page_archive', github: 'everypolitician/scraped_page_archive'
+gem 'scraper_test', github: 'everypolitician/scraper_test'
 gem 'scraperwiki', github: 'openaustralia/scraperwiki-ruby',
                    branch: 'morph_defaults'
 gem 'table_unspanner', github: 'everypolitician/table_unspanner'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,16 @@ GIT
       vcr-archive (~> 0.3.0)
 
 GIT
+  remote: https://github.com/everypolitician/scraper_test.git
+  revision: a8a6c795ea1544bc95e2f7a1dbb132ba8c80ed98
+  specs:
+    scraper_test (0.1.0)
+      minitest (~> 5.0)
+      pry
+      vcr (>= 3.0.3)
+      webmock (>= 2.0)
+
+GIT
   remote: https://github.com/everypolitician/table_unspanner.git
   revision: a70a98a104a75b470f4ea339fdd728366a40b4d8
   specs:
@@ -121,6 +131,7 @@ DEPENDENCIES
   rubocop
   scraped!
   scraped_page_archive!
+  scraper_test!
   scraperwiki!
   table_unspanner!
   vcr

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
 require 'rubocop/rake_task'
+require 'rake/testtask'
 
 RuboCop::RakeTask.new
 
-task default: %w(rubocop)
+require 'scraper_test'
+ScraperTest::RakeTask.new.install_tasks
+
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/*_test.rb']
+end
+
+task test: 'test:data'
+task default: %w(rubocop test)

--- a/test/dummy_test.rb
+++ b/test/dummy_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+describe 'dummy test' do
+  it 'should run' do
+    # This test is included to ensure that
+    # test_helper is run by Travis
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'minitest/around/spec'
+require 'minitest/autorun'
+require 'pry'
+require 'vcr'
+require 'webmock'
+
+VCR.configure do |c|
+  c.cassette_library_dir = 'test/cassettes'
+  c.hook_into :webmock
+end


### PR DESCRIPTION
This PR sets up the test framework in preparation of making further changes:

Adds scraper_test gem to run tests against .yml files.
Configures rake to run custom tests in addition to scraper_test task.
Configures travis to run ensure_regression_tests.

This is a step towards scraping dates of mid-term changes: https://github.com/everypolitician/everypolitician-data/issues/33101